### PR TITLE
Fixed missing python math import

### DIFF
--- a/Python3/demos/sensor_test.py
+++ b/Python3/demos/sensor_test.py
@@ -5,6 +5,7 @@ from klampt.vis.glinterface import GLPluginInterface
 from klampt.model import sensing
 import time
 import random
+import math
 
 try:
 	import matplotlib.pyplot as plt


### PR DESCRIPTION
Added missing math import since the library was used in conversion from degrees to radians in line 53.